### PR TITLE
skip hashicorp/aws v5.98.0

### DIFF
--- a/terraform.json
+++ b/terraform.json
@@ -35,6 +35,18 @@
         "patch"
       ],
       "groupName": "terraform (non-major)"
+    },
+    {
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDepTypes": [
+        "required_provider"
+      ],
+      "matchDepNames": [
+        "aws"
+      ],
+      "allowedVersions": "!/^5\\.98\\.0$/"
     }
   ]
 }


### PR DESCRIPTION
https://registry.terraform.io/v1/providers/hashicorp/aws/5.98.0/download/linux/amd64 returns a 404 error, so lockfile is not updated.
This is not a problem with versions other than 5.98.0, so skip this version.
Revert it after a while.

```
DEBUG: updateArtifacts for updatedPackageFiles (repository=elastic-infra/************, branch=renovate/terraform-non-major)
DEBUG: terraform.updateArtifacts(47hd/versions.tf) (repository=elastic-infra/************, branch=renovate/terraform-non-major)
DEBUG: Found 2 provider deps (repository=elastic-infra/************, branch=renovate/terraform-non-major)
DEBUG: Updating constraint "~> 5.94.0" to replace "~> 5.94.0" with "~> 5.98.0" for "hashicorp/aws" (repository=elastic-infra/************, branch=renovate/terraform-non-major)
DEBUG: Creating hashes for hashicorp/aws@5.98.0 (https://registry.terraform.io/) (repository=elastic-infra/************, branch=renovate/terraform-non-major)
DEBUG: GET https://registry.terraform.io/v1/providers/hashicorp/aws/5.98.0/download/linux/amd64 = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=404 retryCount=0, duration=100) (repository=elastic-infra/************, branch=renovate/terraform-non-major)
DEBUG: Failed to retrieve build (repository=elastic-infra/************, branch=renovate/terraform-non-major)
       "err": {
         "name": "HTTPError",
         "code": "ERR_NON_2XX_3XX_RESPONSE",
         "timings": {
           "start": 1747716426608,
           "socket": 1747716426608,
           "lookup": 1747716426655,
           "connect": 1747716426673,
           "secureConnect": 1747716426690,
           "upload": 1747716426690,
           "response": 1747716426707,
           "end": 1747716426708,
           "phases": {
             "wait": 0,
             "dns": 47,
             "tcp": 18,
             "tls": 17,
             "request": 0,
             "firstByte": 17,
             "download": 1,
             "total": 100
           }
         },
         "message": "Response code 404 (Not Found)",
         "stack": "HTTPError: Response code 404 (Not Found)\n    at Request.<anonymous> (/usr/local/renovate/node_modules/.pnpm/got@11.8.6/node_modules/got/dist/source/as-promise/index.js:118:42)\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)",
         "options": {
           "headers": {
             "user-agent": "RenovateBot/40.18.3 (https://github.com/renovatebot/renovate)",
             "accept": "application/json",
             "accept-encoding": "gzip, deflate, br"
           },
           "url": "https://registry.terraform.io/v1/providers/hashicorp/aws/5.98.0/download/linux/amd64",
           "hostType": "terraform-provider",
           "username": "",
           "password": "",
           "method": "GET",
           "http2": false
         },
         "response": {
           "statusCode": 404,
           "statusMessage": "Not Found",
           "body": {"errors": ["provider platform not found"]},
           "headers": {
             "content-type": "application/json",
             "content-length": "66",
             "connection": "keep-alive",
             "date": "Thu, 15 May 2025 21:46:11 GMT",
             "cache-control": "public, max-age=604800, stale-if-error=31536000",
             "content-encoding": "gzip",
             "last-modified": "Thu, 15 May 2025 21:39:48 GMT",
             "server": "terraform-registry/70ceeb5eb9dd5653c4a735a7ff4562e30122bf68",
             "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
             "vary": "Accept-Encoding,X-Terraform-Version",
             "x-cache": "Error from cloudfront",
             "via": "1.1 31113f2f23c4ce8a8af1d88a37137806.cloudfront.net (CloudFront)",
             "x-amz-cf-pop": "IAD12-P1",
             "x-amz-cf-id": "g6TU4xNlz4DIETTabsmS6tbBjFmUdui1CtV-lHI1HGCJQm36BqPHWg==",
             "age": "370855"
           },
           "httpVersion": "1.1",
           "retryCount": 0
         }
       },
       "url": "https://registry.terraform.io/v1/providers/hashicorp/aws/5.98.0/download/linux/amd64"
```
